### PR TITLE
Fix HuggingFace dataset URL for RI microsimulation

### DIFF
--- a/backend/app/core/dataset.py
+++ b/backend/app/core/dataset.py
@@ -21,8 +21,10 @@ class DatasetManager:
 
         logger.info("Loading RI microsimulation dataset...")
         try:
-            # Load dataset once and keep in memory
-            self.baseline_sim = Microsimulation(dataset="hf://policyengine/test/RI.h5")
+            # Load RI-specific dataset from HuggingFace
+            self.baseline_sim = Microsimulation(
+                dataset="hf://policyengine/policyengine-us-data/states/RI.h5"
+            )
             self._is_loaded = True
             logger.info("✓ RI dataset loaded successfully")
         except Exception as e:

--- a/ri_ctc_calc/calculations/microsimulation.py
+++ b/ri_ctc_calc/calculations/microsimulation.py
@@ -23,8 +23,8 @@ def calculate_aggregate_impact(reform):
     """
     # Load baseline and reform simulations
     # We need to look at NET INCOME change to capture both CTC and exemption effects
-    sim_baseline = Microsimulation(dataset="hf://policyengine/test/RI.h5")
-    sim_reform = Microsimulation(dataset="hf://policyengine/test/RI.h5", reform=reform)
+    sim_baseline = Microsimulation(dataset="hf://policyengine/policyengine-us-data/states/RI.h5")
+    sim_reform = Microsimulation(dataset="hf://policyengine/policyengine-us-data/states/RI.h5", reform=reform)
 
     # Calculate household net income for both scenarios
     # This captures the total impact: CTC + tax savings from exemption changes
@@ -150,7 +150,7 @@ def get_dataset_summary():
     Returns:
         dict: Dataset summary including household counts, children counts, etc.
     """
-    sim = Microsimulation(dataset="hf://policyengine/test/RI.h5")
+    sim = Microsimulation(dataset="hf://policyengine/policyengine-us-data/states/RI.h5")
 
     # Calculate basic counts
     household_count = sim.calculate("household_count", period=2026, map_to="household").sum()
@@ -202,8 +202,8 @@ def calculate_impact_by_household_type(reform):
         dict: Impact statistics by household type
     """
     # Load baseline and reform simulations
-    sim_baseline = Microsimulation(dataset="hf://policyengine/test/RI.h5")
-    sim_reform = Microsimulation(dataset="hf://policyengine/test/RI.h5", reform=reform)
+    sim_baseline = Microsimulation(dataset="hf://policyengine/policyengine-us-data/states/RI.h5")
+    sim_reform = Microsimulation(dataset="hf://policyengine/policyengine-us-data/states/RI.h5", reform=reform)
 
     # Calculate household net income change (captures CTC + exemption effects)
     net_income_baseline = sim_baseline.calculate("household_net_income", period=2026, map_to="household")


### PR DESCRIPTION
## Summary
- Fixed the HuggingFace dataset URL from `hf://policyengine/test/RI.h5` (non-existent) to `hf://policyengine/policyengine-us-data/states/RI.h5` (correct path)
- Updated both `backend/app/core/dataset.py` and `ri_ctc_calc/calculations/microsimulation.py`

## Test plan
- [x] Verified locally that the RI dataset loads successfully via health endpoint
- [x] Verified aggregate impact calculation returns valid results

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)