### PR TITLE
Add GitHub Actions workflow for Cloud Run deployment

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,80 @@
+name: Deploy Backend to Cloud Run
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'backend/**'
+      - 'ri_ctc_calc/**'
+      - 'requirements.txt'
+      - 'Dockerfile'
+      - '.github/workflows/deploy-backend.yml'
+  workflow_dispatch:
+
+env:
+  PROJECT_ID: ri-ctc-calc-2024
+  REGION: us-central1
+  SERVICE_NAME: ri-ctc-calculator-backend
+  IMAGE_NAME: gcr.io/ri-ctc-calc-2024/ri-ctc-calculator-backend
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+
+      - name: Configure Docker for GCR
+        run: gcloud auth configure-docker --quiet
+
+      - name: Build Docker image
+        run: |
+          docker build -t ${{ env.IMAGE_NAME }}:${{ github.sha }} .
+          docker tag ${{ env.IMAGE_NAME }}:${{ github.sha }} ${{ env.IMAGE_NAME }}:latest
+
+      - name: Push Docker image
+        run: |
+          docker push ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          docker push ${{ env.IMAGE_NAME }}:latest
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy ${{ env.SERVICE_NAME }} \
+            --image ${{ env.IMAGE_NAME }}:${{ github.sha }} \
+            --region ${{ env.REGION }} \
+            --platform managed \
+            --allow-unauthenticated \
+            --memory 8Gi \
+            --cpu 2 \
+            --timeout 300 \
+            --quiet
+
+      - name: Verify deployment
+        run: |
+          SERVICE_URL=$(gcloud run services describe ${{ env.SERVICE_NAME }} \
+            --region ${{ env.REGION }} \
+            --format 'value(status.url)')
+          echo "Service URL: $SERVICE_URL"
+
+          # Wait for service to be ready
+          sleep 30
+
+          # Health check
+          curl -sf "${SERVICE_URL}/api/health" || exit 1
+          echo "Health check passed!"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy-backend.yml` to automate Cloud Run deployments
- Triggers on push to master when backend-related files change
- Includes health check verification after deployment

## Setup Required
Before this workflow will work, you need to add a GitHub secret:

1. Go to repo Settings → Secrets and variables → Actions
2. Add a secret named `GCP_SA_KEY` containing the JSON key for a GCP service account with:
   - Cloud Run Admin role
   - Cloud Build Editor role
   - Storage Admin role (for GCR)

## Test plan
- [x] Workflow syntax validated
- [ ] Add GCP_SA_KEY secret to repository
- [ ] Trigger workflow manually via Actions tab to verify

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)