### PR TITLE
Replace Roboto with Inter font

### DIFF
--- a/app.py
+++ b/app.py
@@ -69,7 +69,7 @@ def main():
         f"""
         <style>
         .stApp {{
-            font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif;
+            font-family: 'Inter', 'Helvetica', 'Arial', sans-serif;
         }}
         h1 {{
             color: {COLORS["primary"]};
@@ -939,7 +939,7 @@ def create_chart(
             ),
             plot_bgcolor="white",
             paper_bgcolor="white",
-            font=dict(family="Roboto, sans-serif"),
+            font=dict(family="Inter, sans-serif"),
             legend=dict(
                 orientation="h", yanchor="bottom", y=0.98, xanchor="right", x=1
             ),
@@ -1008,7 +1008,7 @@ def create_chart(
             ),
             plot_bgcolor="white",
             paper_bgcolor="white",
-            font=dict(family="Roboto, sans-serif"),
+            font=dict(family="Inter, sans-serif"),
             showlegend=False,
             margin=dict(l=80, r=40, t=60, b=80),
         )

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 /* Import PolicyEngine fonts */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Roboto:wght@300;400;500;700&family=Public+Sans:wght@400;500;600;700&family=JetBrains+Mono&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Public+Sans:wght@400;500;600;700&family=JetBrains+Mono&display=swap');
 
 :root {
   /* PolicyEngine brand colors */
@@ -31,7 +31,7 @@
 }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   color: var(--text-primary);
   background-color: var(--bg-secondary);
 }
@@ -43,7 +43,7 @@ body {
 
   /* PolicyEngine utility classes */
   .font-body {
-    font-family: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   }
 
   .font-secondary {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -101,9 +101,9 @@ module.exports = {
 
       // Typography from PolicyEngine
       fontFamily: {
-        sans: ['Inter', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'sans-serif'],
+        sans: ['Inter', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'sans-serif'],
         secondary: ['Public Sans', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'sans-serif'],
-        body: ['Roboto', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'sans-serif'],
+        body: ['Inter', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'sans-serif'],
         mono: ['JetBrains Mono', 'Fira Code', 'Consolas', 'monospace'],
       },
 


### PR DESCRIPTION
## Summary
- Replace Roboto font references with Inter in app.py (Plotly chart configs)
- Update frontend/app/globals.css to remove Roboto from Google Fonts import and CSS declarations
- Update frontend/tailwind.config.js font family definitions

## Test plan
- [ ] Verify Streamlit app renders with Inter font
- [ ] Verify frontend renders with Inter font
- [ ] Check Plotly charts use Inter font family

Generated with [Claude Code](https://claude.com/claude-code)