### PR TITLE
Add multizone base path support

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,7 +1,13 @@
 /** @type {import('next').NextConfig} */
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH !== undefined
+  ? process.env.NEXT_PUBLIC_BASE_PATH
+  : '/us/rhode-island-ctc-calculator';
+
 const nextConfig = {
+  ...(basePath ? { basePath } : {}),
   output: 'standalone',
   env: {
+    NEXT_PUBLIC_BASE_PATH: basePath,
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080',
   },
   // Pin the workspace root so Turbopack does not pick up a stray lockfile from


### PR DESCRIPTION
Adds a production base path for the PolicyEngine multizone mount and keeps local/root builds available with `NEXT_PUBLIC_BASE_PATH=` where the app uses Next.js.

Also prefixes root-relative public data/assets where needed so the zone loads correctly behind `policyengine.org` instead of only passing a framework build.

Verification:
- `git diff --check`