### PR TITLE
Add PolicyEngine header

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import './globals.css';
 import Script from 'next/script';
 import Providers from '@/components/Providers';
+import PolicyEngineHeader from '@/components/PolicyEngineHeader';
 
 const GA_ID = 'G-2YHG89FY0N';
 const TOOL_NAME = 'ri-ctc-calculator';
@@ -144,6 +145,7 @@ export default function RootLayout({
         </Script>
       </head>
       <body>
+        <PolicyEngineHeader />
         <Providers>
           {children}
         </Providers>

--- a/frontend/components/PolicyEngineHeader.tsx
+++ b/frontend/components/PolicyEngineHeader.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Header } from "@policyengine/ui-kit";
+
+const navItems = [
+  { label: "Research", href: "https://policyengine.org/us/research" },
+  { label: "Model", href: "https://policyengine.org/us/model" },
+  { label: "API", href: "https://policyengine.org/us/api" },
+  {
+    label: "About",
+    href: "https://policyengine.org/us/team",
+    children: [
+      { label: "Team", href: "https://policyengine.org/us/team" },
+      { label: "Supporters", href: "https://policyengine.org/us/supporters" },
+    ],
+  },
+  { label: "Donate", href: "https://policyengine.org/us/donate" },
+];
+
+const countries = [
+  { id: "us", label: "United States" },
+  { id: "uk", label: "United Kingdom" },
+];
+
+export default function PolicyEngineHeader() {
+  return (
+    <Header
+      navItems={navItems}
+      countries={countries}
+      currentCountry="us"
+      logoHref="https://policyengine.org/us"
+      onCountryChange={(countryId) => {
+        window.location.href = `https://policyengine.org/${countryId}`;
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary\n- render the shared ui-kit PolicyEngine header above the calculator\n- keep existing providers, analytics, and multizone base path unchanged\n\n## Tests\n- bun run lint\n- bun run typecheck\n- bun run build